### PR TITLE
Add backslash to prevent fatal error class Walker_Nav_Menu  not found

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -21,7 +21,7 @@
 
 namespace Salaros\Wordpress;
 
-class Wp_Bootstrap_Navwalker extends Walker_Nav_Menu {
+class Wp_Bootstrap_Navwalker extends \Walker_Nav_Menu {
 
     /**
      * @see Walker::start_lvl()


### PR DESCRIPTION
Add backslash to prevent fatal error class Walker_Nav_Menu  not found.
